### PR TITLE
Updated README to describe Task Forces

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,12 @@ This is a repository for our Task Force Charters.
 
 ## 2019 Task Forces
 
+- Incidents Outside The Carpentries Code of Conduct Committee
+
 ## 2018 Task Forces
 
-- The Carpentries Code of Conduct Reporting Guidelines and Enforcement Guidelines Task Force
+- The Carpentries Code of Conduct [Reporting Guidelines and Enforcement Guidelines Task Force](https://github.com/carpentries/coc-guidelines-taskforce)
+
+- The Carpentries [Instructor Feedback Report Working Group](https://github.com/carpentries/instructor-feedback)
 
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A Task Force report is shared with the Executive Council upon completion of the 
 
 The current mechanism for creation of a Task Force is for the Executive Council or staff to identify needs for information gathering or updates in current policies, guidelines or products, and collaboratively draft a Charter with relevant members of the community. There is also the opportunity to have a mechanism through this repository for people to propose Task Forces, but that mechanism is not yet developed. If you are interested in proposing or leading a Task Force, please get in touch with the Executive Council at [carpentries-executive-council@carpentries.org](mailto:carpentries-executive-council@carpentries.org).
 
-This is a repository for our Task Force Charters and project boards.
+This is a repository for our Task Force Charters and associated GitHub project boards.
 
 ## 2019 Task Forces
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
-# task-forces
-A repository for The Carpentries Task Force charters
+# The Carpentries Task Forces
+
+The Carpentries uses Task Forces to explore ideas and make updates in policy, procedures and guidelines. Task forces bring together a small group of people focused on a particular topic for a set period of time. Task forces are proposed by the community, lesson programs, staff and Executive Council and are approved by the Executive Council. 
+
+Each Task Force includes:
+
+- A Task Force Charter that outlines the context, objectives and deliverables of the Task Force
+- A set timeline for the start and completion of the task force work
+- An associated project for information about the Task Force during its work
+
+A Task Force report is shared with the Executive Council on completion of the work, and deliverables are developed and shared as outlined in the Task Force Charter.
+
+The current mechanism for creation of Task Force is for the Executive Council or staff to identify needs for information gathering or updates in current policies, guidelines or products and collaboratively draft a Charter with relevant members of the community. There is also the opportunity to have a mechanism through this repository for people to propose Task Forces, but that mechanism is not yet developed. If you are interested in proposing or leading a Task Force, please get in touch with the Executive Council at [carpentries-executive-council@carpentries.org](mailto:carpentries-executive-council@carpentries.org).
+
+This is a repository for our Task Force Charters.
+
+## 2019 Task Forces
+
+## 2018 Task Forces
+
+- The Carpentries Code of Conduct Reporting Guidelines and Enforcement Guidelines Task Force
+
+

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ Each Task Force includes:
 
 - A Task Force Charter that outlines the context, objectives and deliverables of the Task Force
 - A set timeline for the start and completion of the task force work
-- An associated project for information about the Task Force during its work
+- An associated public facing GitHub project for information about the Task Force during its work
 
-A Task Force report is shared with the Executive Council on completion of the work, and deliverables are developed and shared as outlined in the Task Force Charter.
+A Task Force report is shared with the Executive Council upon completion of the work, and deliverables are developed and shared as outlined in the Task Force Charter.
 
-The current mechanism for creation of Task Force is for the Executive Council or staff to identify needs for information gathering or updates in current policies, guidelines or products and collaboratively draft a Charter with relevant members of the community. There is also the opportunity to have a mechanism through this repository for people to propose Task Forces, but that mechanism is not yet developed. If you are interested in proposing or leading a Task Force, please get in touch with the Executive Council at [carpentries-executive-council@carpentries.org](mailto:carpentries-executive-council@carpentries.org).
+The current mechanism for creation of a Task Force is for the Executive Council or staff to identify needs for information gathering or updates in current policies, guidelines or products, and collaboratively draft a Charter with relevant members of the community. There is also the opportunity to have a mechanism through this repository for people to propose Task Forces, but that mechanism is not yet developed. If you are interested in proposing or leading a Task Force, please get in touch with the Executive Council at [carpentries-executive-council@carpentries.org](mailto:carpentries-executive-council@carpentries.org).
 
-This is a repository for our Task Force Charters.
+This is a repository for our Task Force Charters and project boards.
 
 ## 2019 Task Forces
 
@@ -23,5 +23,3 @@ This is a repository for our Task Force Charters.
 - The Carpentries Code of Conduct [Reporting Guidelines and Enforcement Guidelines Task Force](https://github.com/carpentries/coc-guidelines-taskforce)
 
 - The Carpentries [Instructor Feedback Report Working Group](https://github.com/carpentries/instructor-feedback)
-
-


### PR DESCRIPTION
Updated README to describe Task Forces and this repository. Setting up this repository to be a place where we can store and share Task Force Charters. 

@k8hertweck @amyehodge @kcranston @kariljordan please add any thoughts or comments on the README. 

We'll put in other PRs to bring past charters here, and can put future ones here. 