### PR TITLE
Added incidents outside cocc task force charter

### DIFF
--- a/2019-07-incidents-outside-cocc.md
+++ b/2019-07-incidents-outside-cocc.md
@@ -1,0 +1,39 @@
+## Task Force Charter: Recommendations for incidents outside The Carpentries Code of Conduct committee
+Approved:  
+Completed:  
+
+__Context__  
+With a growing community and an increasing number of Carpentries spaces (online and in-person), The Carpentries is encountering cases where a response to incidents either in or outside of Carpentries spaces may be appropriate, but are outside our formal guidelines and processes. Our Code of Conduct (CoC) and Code of Conduct Committee are now quite mature and in operation for incidents that fall within their scope. There is less clarity around incidents outside the Code of Conduct committee’s current purview, including incidents that may have occurred outside of Carpentries spaces, incidents that happen within Carpentries spaces that are either not reported or are not yet incidents, or where people would like to share information or get feedback, rather than formally report an incident. These incidents may impact the ability of members to feel safe working in our community. We want to respond to these events in a timely manner and in a consistent way that balances transparency, confidentiality and legal considerations. 
+
+__Objectives__  
+Our objective is to convene a task force that will make recommendations for guidelines, approaches, support structures or policies that could be developed to respond to incidents that happen outside the scope of the Carpentries Code of Conduct committee. We will write a report that the Executive Council can use to plan and execute an implementation strategy. A draft list of tasks to meet our objective is as follows:
+
+- Develop an application process to recruit 2-3 task force members from The Carpentries community.
+- Investigate legal and confidentiality considerations internationally around collecting, acting on and sharing information.
+- Collect concerns around issues that people have been aware of occurring within Carpentries spaces.
+- Collect concerns around issues that people have been aware of occurring outside of Carpentries spaces, that may have impacted our community members or feelings of safety in Carpentries spaces.
+- Develop an understanding of when the community wants The Carpentries to respond to potential incidents and in what ways. 
+- Identify practices of other organizations (e.g. scientific societies, non-profits) for handling incidents outside the scope of their Code of Conduct committee. 
+- Develop recommendations for what types of internal incidents will generate a response from The Carpentries.
+- Develop recommendations for what types of external incidents will generate a Carpentries response.
+- Develop recommendations and scope for new policies / procedures / guidelines for handling out-of-scope incidents, including the responsibility for decisions and communication.
+- Develop recommendations for support structures that could be a part of implementing the recommendations of this Task Force.
+- Communicate outcomes to the broader Carpentries community.
+
+__Deliverables__  
+The following deliverables are the intended outcomes of this task force:
+- Formal report to the Executive Council including: 
+  - Recommendations that can be used to develop support structures and/or draft guidelines for incidents that happen outside the scope of The Carpentries Code of Conduct committee.
+  - Recommendations that can be used to develop support structures and/or draft guidelines for handling incidents that happen within Carpentries spaces that are either not reported or are not yet incidents.
+  - Recommendation report of task force meetings/discussions and recommendations to be shared with the community and Executive Council.
+- Regularly and consistently updating the public [GitHub project](https://github.com/carpentries/task-forces) on the status of this work. 
+
+__Task Force Members__  
+To complete this charge, we will solicit 2-3 task force members from within The Carpentries community having any combination of the following experience and expertise:
+- Having worked on other Code of Conduct committees
+- Legal expertise
+- Expertise in cross-cultural communication
+- Experience writing policy
+- Conflict resolution experience
+- Having worked served on a task force
+- Geographic and language diversity

--- a/2019-07-incidents-outside-cocc.md
+++ b/2019-07-incidents-outside-cocc.md
@@ -1,4 +1,5 @@
-## Task Force Charter: Recommendations for incidents outside The Carpentries Code of Conduct committee
+## Task Force Charter: Recommendations for incidents outside the scope of The Carpentries Code of Conduct committee
+
 Approved:  
 Completed:  
 

--- a/2019-07-incidents-outside-cocc.md
+++ b/2019-07-incidents-outside-cocc.md
@@ -1,30 +1,30 @@
-## Task Force Charter: Recommendations for incidents outside the scope of The Carpentries Code of Conduct committee
+## Task Force Charter: Recommendations for Incidents Outside the Current Scope of The Carpentries Code of Conduct Committee
 
-Approved:  
+Approved: 2019-07-15  
 Completed:  
 
 __Context__  
-With a growing community and an increasing number of Carpentries spaces (online and in-person), The Carpentries is encountering cases where a response to incidents either in or outside of Carpentries spaces may be appropriate, but are outside our formal guidelines and processes. Our Code of Conduct (CoC) and Code of Conduct Committee are now quite mature and in operation for incidents that fall within their scope. There is less clarity around incidents outside the Code of Conduct committee’s current purview, including incidents that may have occurred outside of Carpentries spaces, incidents that happen within Carpentries spaces that are either not reported or are not yet incidents, or where people would like to share information or get feedback, rather than formally report an incident. These incidents may impact the ability of members to feel safe working in our community. We want to respond to these events in a timely manner and in a consistent way that balances transparency, confidentiality and legal considerations. 
+With a growing community and an increasing number of Carpentries spaces (online and in-person), The Carpentries is encountering cases where a response to incidents either in or outside of Carpentries spaces may be appropriate, but are outside our formal guidelines and processes. Our Code of Conduct (CoC) and Code of Conduct Committee are now quite mature and in operation for incidents that fall within its mandate. There is less clarity around incidents outside the Code of Conduct committee’s current mandate, including incidents that may have occurred outside of Carpentries spaces, incidents that happen within Carpentries spaces that are either not reported or are not yet incidents, or where people would like to share information or get feedback, rather than formally report an incident. These incidents may impact the ability of members to feel safe working in our community. We want to respond to these events in a timely manner and in a consistent way that balances transparency, confidentiality and legal considerations. 
 
 __Objectives__  
-Our objective is to convene a task force that will make recommendations for guidelines, approaches, support structures or policies that could be developed to respond to incidents that happen outside the scope of the Carpentries Code of Conduct committee. We will write a report that the Executive Council can use to plan and execute an implementation strategy. A draft list of tasks to meet our objective is as follows:
+Our objective is to convene a task force that will make recommendations for guidelines, approaches, support structures or policies that could be developed to respond to incidents that happen outside the mandate of the Carpentries Code of Conduct committee. We will write a report that the Executive Council can use to plan and execute an implementation strategy. A draft list of tasks to meet our objective is as follows:
 
 - Develop an application process to recruit 2-3 task force members from The Carpentries community.
 - Investigate legal and confidentiality considerations internationally around collecting, acting on and sharing information.
 - Collect concerns around issues that people have been aware of occurring within Carpentries spaces.
 - Collect concerns around issues that people have been aware of occurring outside of Carpentries spaces, that may have impacted our community members or feelings of safety in Carpentries spaces.
 - Develop an understanding of when the community wants The Carpentries to respond to potential incidents and in what ways. 
-- Identify practices of other organizations (e.g. scientific societies, non-profits) for handling incidents outside the scope of their Code of Conduct committee. 
+- Identify practices of other organizations (e.g. scientific societies, non-profits) for handling incidents outside the mandate of their Code of Conduct committee. 
 - Develop recommendations for what types of internal incidents will generate a response from The Carpentries.
 - Develop recommendations for what types of external incidents will generate a Carpentries response.
-- Develop recommendations and scope for new policies / procedures / guidelines for handling out-of-scope incidents, including the responsibility for decisions and communication.
+- Develop recommendations and mandate for new policies / procedures / guidelines for handling out-of-mandate incidents, including the responsibility for decisions and communication.
 - Develop recommendations for support structures that could be a part of implementing the recommendations of this Task Force.
 - Communicate outcomes to the broader Carpentries community.
 
 __Deliverables__  
 The following deliverables are the intended outcomes of this task force:
 - Formal report to the Executive Council including: 
-  - Recommendations that can be used to develop support structures and/or draft guidelines for incidents that happen outside the scope of The Carpentries Code of Conduct committee.
+  - Recommendations that can be used to develop support structures and/or draft guidelines for incidents that happen outside the mandate of The Carpentries Code of Conduct committee.
   - Recommendations that can be used to develop support structures and/or draft guidelines for handling incidents that happen within Carpentries spaces that are either not reported or are not yet incidents.
   - Recommendation report of task force meetings/discussions and recommendations to be shared with the community and Executive Council.
 - Regularly and consistently updating the public [GitHub project](https://github.com/carpentries/task-forces) on the status of this work. 

--- a/2019-07-incidents-outside-cocc.md
+++ b/2019-07-incidents-outside-cocc.md
@@ -1,4 +1,4 @@
-## Task Force Charter: Recommendations for Incidents Outside the Current Scope of The Carpentries Code of Conduct Committee
+## Task Force Charter: Recommendations for Incidents outside the mandate of The Carpentries Code of Conduct committee
 
 Approved: 2019-07-15  
 Completed:  

--- a/2019-07-incidents-outside-cocc.md
+++ b/2019-07-incidents-outside-cocc.md
@@ -26,7 +26,7 @@ The following deliverables are the intended outcomes of this task force:
 - Formal report to the Executive Council including: 
   - Recommendations that can be used to develop support structures and/or draft guidelines for incidents that happen outside the mandate of The Carpentries Code of Conduct committee.
   - Recommendations that can be used to develop support structures and/or draft guidelines for handling incidents that happen within Carpentries spaces that are either not reported or are not yet incidents.
-  - Recommendation report of task force meetings/discussions and recommendations to be shared with the community and Executive Council.
+  - Report of task force meetings/discussions and recommendations to be shared with the community and Executive Council.
 - Regularly and consistently updating the public [GitHub project](https://github.com/carpentries/task-forces) on the status of this work. 
 
 __Task Force Members__  


### PR DESCRIPTION
I've added the task force charter for incidents outside the scope of The Carpentries Code of Conduct Committee.