### PR TITLE
Added task force charter template

### DIFF
--- a/task-force-charter-template.md
+++ b/task-force-charter-template.md
@@ -1,0 +1,31 @@
+## Task Force Charter: [Name of Task Force]
+
+Approval date:  <br/>
+Completion date: 
+
+### Context
+A problem statement, (i.e. 3-5 sentence explanation of the task force). 
+
+__Example:__  
+In the last year, incidents surrounding The Carpentries Code of Conduct (CoC) highlighted issues with enforcing the CoC and adjudicating reported CoC violations. As a result, and due to Software and Data Carpentry having merged to form The Carpentries, there have been updates to governance and policy documents, including updates to the Code of Conduct. Additionally, the Executive Council has expressed concern with the lack of timeliness as it relates to resolving CoC incident reports. The CoC Committee serves to respond and resolve CoC incident reports, and update documentation. Though work has been completed to update our Code of Conduct, the CoC committee lacks the expertise to update the reporting guidelines and enforcement manual.
+
+### Objective
+The overall objective of the Task Force. 
+
+__Example:__  
+The objective of this task force is to update our Reporting Guidelines and Enforcement Manual and Guidelines and processes. We want all members of our community to understand the process, for reporters to feel safe and supported in reporting an incident and in the community, to ensure a confidential process, and for people under review to have access to a fair and unbiased review. We want to be able to handle Code of Conduct reports respectfully, in a timely manner and with appropriate communication and transparency in accordance with our Code of Conduct. 
+
+### Deliverables
+Documents or other outputs from the work.
+
+__Examples:__ 
+1. Revised enforcement manual and reporting guidelines in The Carpentries handbook including update log.   
+2. Blog post summary of task force meetings/discussions with release of enforcement manual and reporting guidelines.   
+3. Incident response checklist to be added to The Carpentries handbook along with revised enforcement manual and reporting guidelines.    
+
+
+### Task Force Members
+
+-<br/>
+-<br/>
+-<br/>


### PR DESCRIPTION
A task force chair can use this template to plan the goals and deliverables of their task force.

@tracykteal adding the task force charter per our meeting notes.