### PR TITLE
DRAFT: adding Lesson Publication Task Force

### DIFF
--- a/2021/Lesson-Publication/Lesson-Publication-Charter.md
+++ b/2021/Lesson-Publication/Lesson-Publication-Charter.md
@@ -5,7 +5,7 @@ Completion date:
 
 #### Context
 
-Members of the Carpentries community contribute to lessons in a variety of ways, from creating them to maintaining repositories. However, there are not well-defined processes for recognizing these contributions in official lesson publications or when lessons should be officially published. Recognition serves to motivate contributors, highlight the work being done within the community, and provide opportunities for professional development for community members. Finally, the skills and responsibilities required for roles in lesson publication may be understood within the Carpentries but not to people outside the community (such as hiring committees).
+Members of the Carpentries community contribute to lessons in a variety of ways, from creating them to maintaining repositories. However, there are not well-defined processes for recognizing the diversity of these contributions in official lesson publications or even when lessons should be officially published. Recognition serves to motivate contributors, highlight the work being done within the community, and provide opportunities for professional development for community members. Finally, the skills and responsibilities required for roles in lesson publication may be understood within the Carpentries but not to people outside the community (such as hiring committees).
 
 #### Objective
 

--- a/2021/Lesson-Publication/Lesson-Publication-Charter.md
+++ b/2021/Lesson-Publication/Lesson-Publication-Charter.md
@@ -1,0 +1,38 @@
+## Task Force Charter: Lesson Publication Task Force
+
+Approval date: <br>
+Completion date:
+
+#### Context
+
+Members of the Carpentries community contribute to lessons in a variety of ways, from creating them to maintaining repositories. However, there are not well-defined processes for recognizing these contributions in official lesson publications or when lessons should be officially published. Recognition serves to motivate contributors, highlight the work being done within the community, and provide opportunities for professional development for community members. Finally, the skills and responsibilities required for roles in lesson publication may be understood within the Carpentries but not to people outside the community (such as hiring committees).
+
+#### Objective
+
+The objective of this task force is to develop guidelines for recognition of contributions to Carpentries lessons in official lesson publications, as well as a process for regular lesson publications. These guidelines will include methodological approaches (e.g. how to quantify contributions, assign authorship on published lessons, and determine when a lesson is ready for a new publication) and technical approaches (e.g. how to collect and store data on various modes of contribution). Community input on these goals will come in the form of an initial survey and the recruitment of Task Force members.
+
+#### Deliverables
+
+1. A document describing:
+	- Types of contributions that deserve lesson authorship or other acknowledgement
+	- A minimum threshold of contribution that constitutes authorship, including the recency of contributions
+	- A method for determining authorship order in official lesson publications
+2. A document describing:
+	- A type of schedule for lesson publications (regularly timed or milestone-based)
+	- Methods for determining lesson publication schedules, 
+	- Whose responsibility it is to track progress and initiate publication
+3. A blog post describing the conclusions reached by the Task Force
+4. A document describing a communications plan for informing relevant community members (Maintainers, contributors, lesson developers, CAC members) about the lesson publication plan
+
+#### Task Force Members
+
+The Task Force should be comprised of a mix of SWC, DC, and LC people, covering the range of roles involved in lesson development and maintenance.
+
+Core Team member (Michael Culshaw-Maurer)
+Lesson Maintainer
+Lesson Contributor
+Lesson Developer
+CAC member
+Senior academic familiar with hiring committees
+Could even be brought in for a single late meeting
+

--- a/2021/Lesson-Publication/README.md
+++ b/2021/Lesson-Publication/README.md
@@ -1,0 +1,2 @@
+## 
+This folder contains task force documents for the Lesson Publication Task Force


### PR DESCRIPTION
This PR adds the charter and a README for the Lesson Publication Task Force into the 2021 folder.